### PR TITLE
Add ability to get current vlc status

### DIFF
--- a/VLC.js
+++ b/VLC.js
@@ -1,10 +1,56 @@
+function updateData() { //a mettre dans dataEvent ? fonction qui s'execute des qu'on recoit un retour sur une autre commande
+	local.sendGET("requests/status.xml");
+}
+
+function dataEvent(data, requestURL) 
+{
+
+	for(i = 0; i < data.split(">").length; i++) {
+		if(data.split(">")[i].split("<")[1] == "/fullscreen") {
+			local.values.fullscreen.set(data.split(">")[i].split("<")[0]);
+		}
+
+		if(data.split(">")[i].split("<")[1] == "/time") {
+			local.values.time.set(data.split(">")[i].split("<")[0]);
+		}
+		
+		if(data.split(">")[i].split("<")[1] == "/length") {
+			local.values.length.set(data.split(">")[i].split("<")[0]);
+		}
+		
+		if(data.split(">")[i].split("<")[1] == "/volume") {
+			local.values.volume.set(data.split(">")[i].split("<")[0]);
+		}
+
+		if(data.split(">")[i].split("<")[1] == "/loop") {
+			if(data.split(">")[i].split("<")[0] == "true") { local.values.loop.set("true"); }
+			else { local.values.loop.set("false"); }
+		}
+
+		if(data.split(">")[i].split("<")[1] == "/repeat") {
+			if(data.split(">")[i].split("<")[0] == "true") { local.values.loop.set("repeat"); }
+		}
+
+		if(data.split(">")[i].split("<")[1] == "info name='filename'") {
+			local.values.videoName.set(data.split(">")[i+1].split("<")[0]);
+		}
+
+		if(data.split(">")[i].split("<")[1] == "/state") {
+			local.values.state.set(data.split(">")[i].split("<")[0]);
+		}
+
+	}
+	
+	
+}
+
 function play()
 {
 	sendCommand("pl_play");
 }
 
 function pause()
-{
+{ 
 	sendCommand("pl_pause");
 }
 
@@ -23,7 +69,6 @@ function playFile(file)
 function previous()
 {
 	sendCommand("pl_previous");
-
 }
 
 function next()
@@ -49,7 +94,7 @@ function setVolume(value)
 	sendCommand("volume&val="+parseInt(value*255));
 }
 
-function 	sendCommand(command)
+function sendCommand(command)
 {
 	local.sendGET("requests/status.xml?command="+command);
 }

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"type": "HTTP",
 	"path": "Software",
 	
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Control VLC through HTTP. This module requires at least version 1.7.3b1 of Chataigne ! If you're having troubles, please click the link below and see how to set it up.",
 	"url":"https://github.com/benkuper/VLC-Chataigne-Module",
 	"downloadURL": "https://github.com/benkuper/VLC-Chataigne-module/archive/master.zip",
@@ -34,11 +34,46 @@
 		"VLC.js"
 	],
 	
-	"values": {
+	"values":
+	{
+		"Fullscreen":{
+			"type": "String",
+			"readOnly": true
+		},
+		"Time":{
+			"type": "String",
+			"readOnly": true
+		},
+		"Length": {
+			"type": "String",
+			"readOnly": true
+		},
+		"Volume":{
+			"type": "String",
+			"readOnly": true
+		},
+		"Loop":{
+			"type": "String",
+			"readOnly": true
+		},
+		"Video name": {
+			"type": "String",
+			"readOnly": true
+		},
+		"State": {
+			"type": "String",
+			"readOnly": true
+		}
 	},
 	
 	"commands": {
 		
+		"Update status":
+		{
+			"menu":"",
+			"callback":"updateData"
+		},
+
 		"Play":
 		{
 			"menu":"",
@@ -50,6 +85,7 @@
 			"menu":"",
 			"callback":"pause"
 		},
+
 		"Stop":
 		{
 			"menu":"",


### PR DESCRIPTION
Hi Ben,

I just add a status visualization for some indicators.
It's updated at any request from Chataigne to VLC Client (like Play, Pause, ...). But add added to a "Update status" command.

![image](https://github.com/benkuper/VLC-Chataigne-Module/assets/18584249/2e422465-dfdc-4c06-83bd-913f3018c882)
