### PR TITLE
Add 'repeat' and 'position' status 

### DIFF
--- a/VLC.js
+++ b/VLC.js
@@ -49,6 +49,10 @@ function dataEvent(data, requestURL) {
 			local.values.state.set(data.split(">")[i].split("<")[0]);
 		}
 
+		if (data.split(">")[i].split("<")[1] == "/position") {
+			local.values.position.set(data.split(">")[i].split("<")[0]);
+		}
+
 	}
 
 

--- a/VLC.js
+++ b/VLC.js
@@ -37,7 +37,8 @@ function dataEvent(data, requestURL) {
 		}
 
 		if (data.split(">")[i].split("<")[1] == "/repeat") {
-			if (data.split(">")[i].split("<")[0] == "true") { local.values.loop.set("repeat"); }
+			if (data.split(">")[i].split("<")[0] == "true") { local.values.repeat.set("true"); }
+			else { local.values.repeat.set("false"); }
 		}
 
 		if (data.split(">")[i].split("<")[1] == "info name='filename'") {

--- a/module.json
+++ b/module.json
@@ -68,6 +68,10 @@
 		"State": {
 			"type": "String",
 			"readOnly": true
+		},
+		"Position": {
+			"type": "String",
+			"readOnly": true
 		}
 	},
 	

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
 	"type": "HTTP",
 	"path": "Software",
 	
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "Control VLC through HTTP. This module requires at least version 1.7.3b1 of Chataigne ! If you're having troubles, please click the link below and see how to set it up.",
 	"url":"https://github.com/benkuper/VLC-Chataigne-Module",
 	"downloadURL": "https://github.com/benkuper/VLC-Chataigne-module/archive/master.zip",

--- a/module.json
+++ b/module.json
@@ -57,6 +57,10 @@
 			"type": "String",
 			"readOnly": true
 		},
+		"Repeat":{
+			"type": "String",
+			"readOnly": true
+		},
 		"Video name": {
 			"type": "String",
 			"readOnly": true


### PR DESCRIPTION
This adds more status values.
The 'repeat' status was previously reported as a special value in the 'loop' status field. This was not reliable. It depends on the position of the 'repeat' and 'loop' XML element in VLC's status file because the script is not doing real XML parsing but merely looking for the tag names. I encountered a situation where the 'loop' status was 'false', even when 'repeat' was on in VLC. Therefore I separated the values. 
I also added the 'position' value which gives the progress of the playback as a value between 0 and 1.

Tested with Chataigne 1.9.24 and VLC 3.0.21.
